### PR TITLE
feat: implement static UI for Progress screen with calendar, weekly s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,6 @@ To join the team or collaborate - please email me at tilek.dzenisev@gmail.com.
 
 ## License
 
-© 2025 Manavolt. All rights reserved.
+© 2025 Manavault. All rights reserved.
 
 This repository is licensed under the **MIT License**. See the [LICENSE](./LICENSE) file for details.

--- a/app/(tabs)/progress/index.tsx
+++ b/app/(tabs)/progress/index.tsx
@@ -1,10 +1,38 @@
-import { View, Text } from 'react-native';
-import React from 'react';
+// import { View, Text } from 'react-native';
+// import React from 'react';
 
-export default function index() {
+// export default function index() {
+//   return (
+//     <View>
+//       <Text>Progress</Text>
+//     </View>
+//   );
+// }
+import React from 'react';
+import { View, Text, ScrollView } from 'react-native';
+import tw from '@/lib/design/tw';
+import LayoutWrapper from '@/components/LayoutWrappe/LayoutWrapper';
+import ProgressCalendar from '@/components/ProgressScreen/ProgressCalendar';
+import WeeklyStats from '@/components/ProgressScreen/WeeklyStats';
+import Achievements from '@/components/ProgressScreen/Achievements';
+
+export default function ProgressScreen() {
   return (
-    <View>
-      <Text>Progress</Text>
-    </View>
+    <LayoutWrapper>
+      <ScrollView contentContainerStyle={tw`pb-6`}>
+        <View style={tw`mb-4`}>
+          <Text style={tw`text-2xl font-bold text-primary`}>
+            Progress Tracking
+          </Text>
+          <Text style={tw`text-gray-500`}>See how far you&apos;ve come!</Text>
+        </View>
+
+        <ProgressCalendar />
+
+        <WeeklyStats />
+
+        <Achievements />
+      </ScrollView>
+    </LayoutWrapper>
   );
 }

--- a/components/ProgressScreen/Achievements.tsx
+++ b/components/ProgressScreen/Achievements.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import tw from '@/lib/design/tw';
+
+const achievements = [
+  {
+    title: 'First week completed!',
+    icon: '🎯',
+    date: 'June 7',
+  },
+  {
+    title: '10 days in a row',
+    icon: '🔥',
+    date: 'June 17',
+  },
+  {
+    title: '50 exercises done',
+    icon: '⭐',
+    date: 'June 19',
+  },
+];
+
+export default function Achievements() {
+  return (
+    <View style={tw`bg-white rounded-2xl p-4 shadow-sm`}>
+      <Text style={tw`text-xl font-bold text-primary mb-2`}>
+        Recent Achievements
+      </Text>
+
+      {achievements.map((ach, index) => (
+        <View
+          key={index}
+          style={tw`flex-row justify-between items-center mb-3`}
+        >
+          <View style={tw`flex-row items-center gap-2`}>
+            <Text style={tw`text-lg`}>{ach.icon}</Text>
+            <View>
+              <Text style={tw`text-primary`}>{ach.title}</Text>
+              <Text style={tw`text-gray-400 text-sm`}>{ach.date}</Text>
+            </View>
+          </View>
+          <Text style={tw`text-primary`}>Completed</Text>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/components/ProgressScreen/ProgressCalendar.tsx
+++ b/components/ProgressScreen/ProgressCalendar.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import tw from '@/lib/design/tw';
+
+export default function ProgressCalendar() {
+  return (
+    <View style={tw`bg-white rounded-2xl p-4 mb-4 shadow-sm`}>
+      <Text style={tw`text-xl font-bold text-primary mb-2`}>June 2025</Text>
+
+      <View style={tw`flex-row justify-between mb-2`}>
+        {['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'].map((day) => (
+          <Text key={day} style={tw`text-gray-400 text-xs text-center w-8`}>
+            {day}
+          </Text>
+        ))}
+      </View>
+
+      <View style={tw`flex-row flex-wrap`}>
+        {[...Array(30)].map((_, index) => {
+          const day = index + 1;
+          const isChecked = [1, 2, 5, 8, 9, 10, 12, 15, 16, 17, 19].includes(
+            day,
+          );
+
+          return (
+            <View key={day} style={tw`w-1/7 h-10 items-center justify-center`}>
+              <View
+                style={tw`w-8 h-8 rounded-full ${
+                  isChecked
+                    ? 'bg-teal-100 border border-teal-600'
+                    : 'bg-gray-100'
+                } items-center justify-center`}
+              >
+                <Text style={tw`text-primary text-sm`}>{day}</Text>
+              </View>
+            </View>
+          );
+        })}
+      </View>
+
+      <View style={tw`mt-4 items-center`}>
+        <Text style={tw`text-3xl font-bold text-primary`}>12</Text>
+        <Text style={tw`text-sm text-gray-500`}>days completed this month</Text>
+      </View>
+    </View>
+  );
+}

--- a/components/ProgressScreen/WeeklyStats.tsx
+++ b/components/ProgressScreen/WeeklyStats.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import tw from '@/lib/design/tw';
+
+const stats = [
+  { week: 'Week 1', progress: 71, completed: 5 },
+  { week: 'Week 2', progress: 86, completed: 6 },
+  { week: 'Week 3', progress: 57, completed: 4 },
+  { week: 'This week', progress: 40, completed: 2 },
+];
+
+export default function WeeklyStats() {
+  return (
+    <View style={tw`bg-white rounded-2xl p-4 mb-4 shadow-sm`}>
+      <Text style={tw`text-xl font-bold text-primary mb-2`}>
+        Weekly Statistics
+      </Text>
+
+      {stats.map(({ week, progress, completed }, index) => (
+        <View key={index} style={tw`mb-3`}>
+          <View style={tw`flex-row justify-between mb-1`}>
+            <Text style={tw`text-primary`}>{week}</Text>
+            <Text style={tw`text-primary`}>{progress}%</Text>
+          </View>
+          <View style={tw`h-2 rounded-full bg-gray-200 overflow-hidden`}>
+            <View
+              style={[
+                tw`h-full rounded-full bg-teal-400`,
+                { width: `${progress}%` },
+              ]}
+            />
+          </View>
+          <Text style={tw`text-gray-400 text-xs mt-1`}>{completed}/7 days</Text>
+        </View>
+      ))}
+    </View>
+  );
+}


### PR DESCRIPTION
This PR adds the static UI for the Progress screen:

- Calendar view with marked completed days
- Weekly progress bars for the last 4 weeks
- Achievements section showing recent milestones

This is a static version no backend or local storage yet. All values are mocked for MVP.

Next step: connect this screen to real progress data when backend is ready.


### ✅ Checklist

- [✅] Code is formatted & linted
- [✅] Only relevant files are changed
- [✅] PR title follows conventional commits (e.g. `fix:`, `feat:`, `docs:`)
- [✅] I’ve tested my changes and reviewed the diff before submitting
